### PR TITLE
fix: Update CI configuration files to use latest version

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,21 @@
+name: 'Lock Threads'
+
+on:
+  schedule:
+    - cron: '50 1 * * *'
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-comment: >
+            I'm going to lock this issue because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
+            If you have found a problem that seems similar to this, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
+          issue-inactive-days: '30'
+          pr-comment: >
+            I'm going to lock this pull request because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
+            If you have found a problem that seems related to this change, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
+          pr-inactive-days: '30'

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       # Please look up the latest version from
       # https://github.com/amannn/action-semantic-pull-request/releases
-      - uses: amannn/action-semantic-pull-request@v3.4.6
+      - uses: amannn/action-semantic-pull-request@v5.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,11 +17,11 @@ jobs:
       directories: ${{ steps.dirs.outputs.directories }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get root directories
         id: dirs
-        uses: clowdhaus/terraform-composite-actions/directories@v1.3.0
+        uses: clowdhaus/terraform-composite-actions/directories@v1.8.0
 
   preCommitMinVersions:
     name: Min TF pre-commit
@@ -32,18 +32,18 @@ jobs:
         directory: ${{ fromJson(needs.collectInputs.outputs.directories) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.0.3
+        uses: clowdhaus/terraform-min-max@v1.2.0
         with:
           directory: ${{ matrix.directory }}
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
         # Run only validate pre-commit check on min version supported
         if: ${{ matrix.directory !=  '.' }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.3.0
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.8.0
         with:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
           args: 'terraform_validate --color=always --show-diff-on-failure --files ${{ matrix.directory }}/*'
@@ -51,7 +51,7 @@ jobs:
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
         # Run only validate pre-commit check on min version supported
         if: ${{ matrix.directory ==  '.' }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.3.0
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.8.0
         with:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
           args: 'terraform_validate --color=always --show-diff-on-failure --files $(ls *.tf)'
@@ -62,17 +62,17 @@ jobs:
     needs: collectInputs
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.0.3
+        uses: clowdhaus/terraform-min-max@v1.2.0
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.maxVersion }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.3.0
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.8.0
         with:
           terraform-version: ${{ steps.minMax.outputs.maxVersion }}
           terraform-docs-version: ${{ env.TERRAFORM_DOCS_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     if: github.repository_owner == 'terraform-aws-modules'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/stale-actions.yaml
+++ b/.github/workflows/stale-actions.yaml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v6
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           # Staling issues and PR's

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.68.1
+    rev: v1.76.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -23,7 +23,7 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,12 +1,12 @@
 # Application
 output "application_arn" {
   description = "The Amazon Resource Name (ARN) of the AppConfig Application"
-  value       = element(concat(aws_appconfig_application.this.*.arn, [""]), 0)
+  value       = try(aws_appconfig_application.this[0].arn, "")
 }
 
 output "application_id" {
   description = "The AppConfig application ID"
-  value       = element(concat(aws_appconfig_application.this.*.id, [""]), 0)
+  value       = try(aws_appconfig_application.this[0].id, "")
 }
 
 # Environments
@@ -18,44 +18,44 @@ output "environments" {
 # Configuration profile
 output "configuration_profile_arn" {
   description = "The Amazon Resource Name (ARN) of the AppConfig Configuration Profile"
-  value       = element(concat(aws_appconfig_configuration_profile.this.*.arn, [""]), 0)
+  value       = try(aws_appconfig_configuration_profile.this[0].arn, "")
 }
 
 output "configuration_profile_configuration_profile_id" {
   description = "The configuration profile ID"
-  value       = element(concat(aws_appconfig_configuration_profile.this.*.configuration_profile_id, [""]), 0)
+  value       = try(aws_appconfig_configuration_profile.this[0].configuration_profile_id, "")
 }
 
 output "configuration_profile_id" {
   description = "The AppConfig configuration profile ID and application ID separated by a colon (:)"
-  value       = element(concat(aws_appconfig_configuration_profile.this.*.id, [""]), 0)
+  value       = try(aws_appconfig_configuration_profile.this[0].id, "")
 }
 
 # Hosted configuration version
 output "hosted_configuration_version_arn" {
   description = "The Amazon Resource Name (ARN) of the AppConfig hosted configuration version"
-  value       = element(concat(aws_appconfig_hosted_configuration_version.this.*.arn, [""]), 0)
+  value       = try(aws_appconfig_hosted_configuration_version.this[0].arn, "")
 }
 
 output "hosted_configuration_version_id" {
   description = "The AppConfig application ID, configuration profile ID, and version number separated by a slash (/)"
-  value       = element(concat(aws_appconfig_hosted_configuration_version.this.*.id, [""]), 0)
+  value       = try(aws_appconfig_hosted_configuration_version.this[0].id, "")
 }
 
 output "hosted_configuration_version_version_number" {
   description = "The version number of the hosted configuration"
-  value       = element(concat(aws_appconfig_hosted_configuration_version.this.*.version_number, [""]), 0)
+  value       = try(aws_appconfig_hosted_configuration_version.this[0].version_number, "")
 }
 
 # Deployment strategy
 output "deployment_strategy_arn" {
   description = "The Amazon Resource Name (ARN) of the AppConfig Deployment Strategy"
-  value       = element(concat(aws_appconfig_deployment_strategy.this.*.arn, [""]), 0)
+  value       = try(aws_appconfig_deployment_strategy.this[0].arn, "")
 }
 
 output "deployment_strategy_id" {
   description = "The AppConfig deployment strategy ID"
-  value       = element(concat(aws_appconfig_deployment_strategy.this.*.id, [""]), 0)
+  value       = try(aws_appconfig_deployment_strategy.this[0].id, "")
 }
 
 # Deployment
@@ -67,45 +67,45 @@ output "deployments" {
 # Retrieval role
 output "retrieval_role_arn" {
   description = "Amazon Resource Name (ARN) specifying the retrieval role"
-  value       = element(concat(aws_iam_role.retrieval.*.arn, [""]), 0)
+  value       = try(aws_iam_role.retrieval[0].arn, "")
 }
 
 output "retrieval_role_id" {
   description = "Name of the retrieval role"
-  value       = element(concat(aws_iam_role.retrieval.*.id, [""]), 0)
+  value       = try(aws_iam_role.retrieval[0].id, "")
 }
 
 output "retrieval_role_unique_id" {
   description = "Stable and unique string identifying the retrieval role"
-  value       = element(concat(aws_iam_role.retrieval.*.unique_id, [""]), 0)
+  value       = try(aws_iam_role.retrieval[0].unique_id, "")
 }
 
 output "retrieval_role_name" {
   description = "Name of the retrieval role"
-  value       = element(concat(aws_iam_role.retrieval.*.name, [""]), 0)
+  value       = try(aws_iam_role.retrieval[0].name, "")
 }
 
 output "retrieval_role_policy_arn" {
   description = "The ARN assigned by AWS to the retrieval role policy"
-  value       = element(concat(aws_iam_policy.retrieval.*.arn, [""]), 0)
+  value       = try(aws_iam_policy.retrieval[0].arn, "")
 }
 
 output "retrieval_role_policy_id" {
   description = "The ARN assigned by AWS to the retrieval role policy"
-  value       = element(concat(aws_iam_policy.retrieval.*.id, [""]), 0)
+  value       = try(aws_iam_policy.retrieval[0].id, "")
 }
 
 output "retrieval_role_policy_name" {
   description = "The name of the policy"
-  value       = element(concat(aws_iam_policy.retrieval.*.name, [""]), 0)
+  value       = try(aws_iam_policy.retrieval[0].name, "")
 }
 
 output "retrieval_role_policy_policy" {
   description = "The retrieval role policy document"
-  value       = element(concat(aws_iam_policy.retrieval.*.policy, [""]), 0)
+  value       = try(aws_iam_policy.retrieval[0].policy, "")
 }
 
 output "retrieval_role_policy_policy_id" {
   description = "The retrieval role policy ID"
-  value       = element(concat(aws_iam_policy.retrieval.*.policy_id, [""]), 0)
+  value       = try(aws_iam_policy.retrieval[0].policy_id, "")
 }


### PR DESCRIPTION
## Description

- Update GitHub action versions to use latest. This remove warnings related to https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- Ensure pre-commit config is aligned with latest
- Add `lock.yml` workflow to automatically lock issues and PRs after 30 days. Theres a lot "Me too" or "I have this issue, when will this get fixed" on really old/stale issues and in order to properly triage, users need to supply their configurations. This workflow is pulled from the AWS provider's repo to force users to fill out a proper issue ticket and keep chatter out of merged PRs or old issues

## Motivation and Context

- Patch warnings on CI checks to keep output clean
- Focus on new issues and PRs

## Breaking Changes

- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
