### PR TITLE
fix: Do not create a deployment when a version is not provided

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -91,7 +91,7 @@ resource "aws_appconfig_deployment_strategy" "this" {
 }
 
 resource "aws_appconfig_deployment" "this" {
-  for_each = var.create ? var.environments : {}
+  for_each = var.create && (var.deployment_configuration_version != null) ? var.environments : {}
 
   description              = coalesce(var.deployment_description, var.description)
   application_id           = aws_appconfig_application.this[0].id


### PR DESCRIPTION
## Description
Update the condition to create a aws_appconfig_deployment to check if a version is passed

## Motivation and Context
If we want to create an AppConfig without a deployment and do not set var.deployment_configuration_version, the module returns an error because it tries to create a depyment version even if it is not set

## Breaking Changes
This change does not break backwards compatibility with the current major version

## How Has This Been Tested?
I updated the examples/ssm_parameter and tested it locally using the pre-commit but did not include the change to the example in this PR
