### PR TITLE
fix: Update CI workflow versions to remove deprecated runtime warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.83.5
+    rev: v1.88.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate


### PR DESCRIPTION
## Description

- Update CI workflow versions to remove deprecated runtime warnings

## Motivation and Context

- Updates our workflows to use the latest versions
- Removes the `deprecated runtime` warnings from the workflow execution output

## Breaking Changes

- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ ] I have executed `pre-commit run -a` on my pull request
