### PR TITLE
fix: Update CI workflow versions to latest

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       # Please look up the latest version from
       # https://github.com/amannn/action-semantic-pull-request/releases
-      - uses: amannn/action-semantic-pull-request@v5.4.0
+      - uses: amannn/action-semantic-pull-request@v5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,8 +7,8 @@ on:
       - master
 
 env:
-  TERRAFORM_DOCS_VERSION: v0.16.0
-  TFLINT_VERSION: v0.50.3
+  TERRAFORM_DOCS_VERSION: v0.19.0
+  TFLINT_VERSION: v0.53.0
 
 jobs:
   collectInputs:
@@ -45,14 +45,14 @@ jobs:
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.3.0
+        uses: clowdhaus/terraform-min-max@v1.3.1
         with:
           directory: ${{ matrix.directory }}
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
         # Run only validate pre-commit check on min version supported
         if: ${{ matrix.directory !=  '.' }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.9.0
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.11.1
         with:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
           tflint-version: ${{ env.TFLINT_VERSION }}
@@ -61,7 +61,7 @@ jobs:
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
         # Run only validate pre-commit check on min version supported
         if: ${{ matrix.directory ==  '.' }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.9.0
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.11.1
         with:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
           tflint-version: ${{ env.TFLINT_VERSION }}
@@ -88,10 +88,10 @@ jobs:
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.3.0
+        uses: clowdhaus/terraform-min-max@v1.3.1
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.maxVersion }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.9.0
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.11.1
         with:
           terraform-version: ${{ steps.minMax.outputs.maxVersion }}
           tflint-version: ${{ env.TFLINT_VERSION }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.88.0
+    rev: v1.96.1
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
@@ -21,10 +21,9 @@ repos:
           - '--args=--only=terraform_required_providers'
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
-          - '--args=--only=terraform_unused_required_providers'
       - id: terraform_validate
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 - [SSM Document](https://github.com/terraform-aws-modules/terraform-aws-appconfig/tree/master/examples/ssm-document)
 - [SSM Parameter](https://github.com/terraform-aws-modules/terraform-aws-appconfig/tree/master/examples/ssm-parameter)
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -181,7 +181,7 @@ No modules.
 | <a name="output_retrieval_role_policy_policy"></a> [retrieval\_role\_policy\_policy](#output\_retrieval\_role\_policy\_policy) | The retrieval role policy document |
 | <a name="output_retrieval_role_policy_policy_id"></a> [retrieval\_role\_policy\_policy\_id](#output\_retrieval\_role\_policy\_policy\_id) | The retrieval role policy ID |
 | <a name="output_retrieval_role_unique_id"></a> [retrieval\_role\_unique\_id](#output\_retrieval\_role\_unique\_id) | Stable and unique string identifying the retrieval role |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->
 
 ## License
 

--- a/examples/appconfig-hosted/README.md
+++ b/examples/appconfig-hosted/README.md
@@ -20,7 +20,7 @@ $ terraform apply
 
 Note that this example may create resources which will incur monetary charges on your AWS bill. Run `terraform destroy` when you no longer need these resources.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -79,6 +79,6 @@ No inputs.
 | <a name="output_retrieval_role_policy_policy"></a> [retrieval\_role\_policy\_policy](#output\_retrieval\_role\_policy\_policy) | The retrieval role policy document |
 | <a name="output_retrieval_role_policy_policy_id"></a> [retrieval\_role\_policy\_policy\_id](#output\_retrieval\_role\_policy\_policy\_id) | The retrieval role policy ID |
 | <a name="output_retrieval_role_unique_id"></a> [retrieval\_role\_unique\_id](#output\_retrieval\_role\_unique\_id) | Stable and unique string identifying the retrieval role |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->
 
 Apache-2.0 Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-aws-appconfig/blob/master/LICENSE).

--- a/examples/s3/README.md
+++ b/examples/s3/README.md
@@ -19,7 +19,7 @@ $ terraform apply
 
 Note that this example may create resources which will incur monetary charges on your AWS bill. Run `terraform destroy` when you no longer need these resources.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -81,6 +81,6 @@ No inputs.
 | <a name="output_retrieval_role_policy_policy"></a> [retrieval\_role\_policy\_policy](#output\_retrieval\_role\_policy\_policy) | The retrieval role policy document |
 | <a name="output_retrieval_role_policy_policy_id"></a> [retrieval\_role\_policy\_policy\_id](#output\_retrieval\_role\_policy\_policy\_id) | The retrieval role policy ID |
 | <a name="output_retrieval_role_unique_id"></a> [retrieval\_role\_unique\_id](#output\_retrieval\_role\_unique\_id) | Stable and unique string identifying the retrieval role |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->
 
 Apache-2.0 Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-aws-appconfig/blob/master/LICENSE).

--- a/examples/ssm-document/README.md
+++ b/examples/ssm-document/README.md
@@ -18,7 +18,7 @@ $ terraform apply
 
 Note that this example may create resources which will incur monetary charges on your AWS bill. Run `terraform destroy` when you no longer need these resources.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -74,6 +74,6 @@ No inputs.
 | <a name="output_retrieval_role_policy_policy"></a> [retrieval\_role\_policy\_policy](#output\_retrieval\_role\_policy\_policy) | The retrieval role policy document |
 | <a name="output_retrieval_role_policy_policy_id"></a> [retrieval\_role\_policy\_policy\_id](#output\_retrieval\_role\_policy\_policy\_id) | The retrieval role policy ID |
 | <a name="output_retrieval_role_unique_id"></a> [retrieval\_role\_unique\_id](#output\_retrieval\_role\_unique\_id) | Stable and unique string identifying the retrieval role |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->
 
 Apache-2.0 Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-aws-appconfig/blob/master/LICENSE).

--- a/examples/ssm-parameter/README.md
+++ b/examples/ssm-parameter/README.md
@@ -19,7 +19,7 @@ $ terraform apply
 
 Note that this example may create resources which will incur monetary charges on your AWS bill. Run `terraform destroy` when you no longer need these resources.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -78,6 +78,6 @@ No inputs.
 | <a name="output_retrieval_role_policy_policy"></a> [retrieval\_role\_policy\_policy](#output\_retrieval\_role\_policy\_policy) | The retrieval role policy document |
 | <a name="output_retrieval_role_policy_policy_id"></a> [retrieval\_role\_policy\_policy\_id](#output\_retrieval\_role\_policy\_policy\_id) | The retrieval role policy ID |
 | <a name="output_retrieval_role_unique_id"></a> [retrieval\_role\_unique\_id](#output\_retrieval\_role\_unique\_id) | Stable and unique string identifying the retrieval role |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->
 
 Apache-2.0 Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-aws-appconfig/blob/master/LICENSE).


### PR DESCRIPTION
## Description

- Update CI workflow versions to latest

## Motivation and Context

- Updates our workflows to use the latest versions
- Removes warnings for Python 3.12 in runners

## Breaking Changes

- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
